### PR TITLE
Add sbf namespace to end.h and move implementation to end.cpp

### DIFF
--- a/end.cpp
+++ b/end.cpp
@@ -1,0 +1,14 @@
+#include "end.h"
+
+namespace sbf {
+
+int is_big_endian(void){
+	union {
+		uint32_t i;
+		char c[4];
+	} bi = { 0x01020304 };
+
+	return bi.c[0] == 1;
+}
+
+} //namespace sbf

--- a/end.h
+++ b/end.h
@@ -26,14 +26,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdint.h>
 
-int is_big_endian(void)
-{
-	union {
-		uint32_t i;
-		char c[4];
-	} bi = { 0x01020304 };
+namespace sbf {
 
-	return bi.c[0] == 1;
-}
+int is_big_endian(void);
+
+} //namespace sbf
 
 #endif /* END_H */


### PR DESCRIPTION
- Moved the function `is_big_endian` to the `sbf` namespace, so that it doesn't conflict with the global scope.
- Separated the header from the implementation, so that it follows C++ standard (and g++ doesn't mistake it for a double definition of the same function).