### PR TITLE
Moved methods to sbf namespace and add const keywords

### DIFF
--- a/base64.cpp
+++ b/base64.cpp
@@ -34,11 +34,11 @@ static const std::string base64_chars =
              "0123456789+/";
 
 
-static inline bool is_base64(unsigned char c) {
+static inline bool is_base64(unsigned char c) const {
   return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
+std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) const {
   std::string ret;
   int i = 0;
   int j = 0;
@@ -81,7 +81,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 
 }
 
-std::string base64_decode(std::string const& encoded_string) {
+std::string base64_decode(std::string const& encoded_string) const {
   int in_len = encoded_string.size();
   int i = 0;
   int j = 0;

--- a/base64.cpp
+++ b/base64.cpp
@@ -28,17 +28,19 @@
 #include "base64.h"
 #include <iostream>
 
+namespace sbf {
+
 static const std::string base64_chars = 
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
 
 
-static inline bool is_base64(unsigned char c) const {
+static inline bool is_base64(const unsigned char c) {
   return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) const {
+std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
   std::string ret;
   int i = 0;
   int j = 0;
@@ -81,7 +83,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 
 }
 
-std::string base64_decode(std::string const& encoded_string) const {
+std::string base64_decode(std::string const& encoded_string) {
   int in_len = encoded_string.size();
   int i = 0;
   int j = 0;
@@ -121,3 +123,5 @@ std::string base64_decode(std::string const& encoded_string) const {
 
   return ret;
 }
+
+} // namespace sbf

--- a/base64.h
+++ b/base64.h
@@ -1,4 +1,4 @@
 #include <string>
 
-std::string base64_encode(unsigned char const* , unsigned int len);
-std::string base64_decode(std::string const& s);
+std::string base64_encode(unsigned char const* , unsigned int len) const;
+std::string base64_decode(std::string const& s) const;

--- a/base64.h
+++ b/base64.h
@@ -1,4 +1,8 @@
 #include <string>
 
-std::string base64_encode(unsigned char const* , unsigned int len) const;
-std::string base64_decode(std::string const& s) const;
+namespace sbf {
+
+std::string base64_encode(unsigned char const* , unsigned int len);
+std::string base64_decode(std::string const& s);
+
+} // namespace sbf

--- a/sbf.cpp
+++ b/sbf.cpp
@@ -61,7 +61,7 @@ void SBF::SetHashDigestLength()
 // char *d            is the input of the hash value
 // size_t n           is the input length
 // unsigned char *md  is where the output should be written
-void SBF::Hash(char *d, size_t n, unsigned char *md)
+void SBF::Hash(char *d, size_t n, unsigned char *md) const
 {
     switch(this->HASH_family){
         case 1:
@@ -222,7 +222,7 @@ void SBF::SetCell(unsigned int index, int area)
 
 
 // Returns the area label stored at the specified index
-int SBF::GetCell(unsigned int index)
+int SBF::GetCell(unsigned int index) const
 {
     int area;
     switch (this->cell_size){
@@ -251,7 +251,7 @@ int SBF::GetCell(unsigned int index)
 // Prints the filter and related statistics to the standart output
 // mode: 0    prints SBF stats only
 // mode: 1    prints SBF information and the full SBF content
-void SBF::PrintFilter(int mode)
+void SBF::PrintFilter(int mode) const
 {
     int potential_elements;
 
@@ -432,7 +432,7 @@ void SBF::Insert(char *string, int size, int area)
 // belongs to a set, 0 otherwise.
 // char *string     the element to be verified
 // int size         length of the element
-int SBF::Check(char *string, int size)
+int SBF::Check(char *string, int size) const
 {
     char* buffer = new char[size];
     int area = 0;
@@ -622,14 +622,14 @@ void SBF::SetAreaFpp()
 
 
 // Returns the number of inserted elements for the input area
-int SBF::GetAreaMembers(int area)
+int SBF::GetAreaMembers(int area) const
 {
 	return this->AREA_members[area];
 }
 
 
 // Returns the sparsity of the entire SBF
-float SBF::GetFilterSparsity()
+float SBF::GetFilterSparsity() const
 {
     float ret;
     int sum = 0;
@@ -644,7 +644,7 @@ float SBF::GetFilterSparsity()
 
 // Returns the a-priori false positive probability over the entire filter
 // (i.e. not area-specific)
-float SBF::GetFilterAPrioriFpp()
+float SBF::GetFilterAPrioriFpp() const
 {
 	double p;
 	
@@ -658,7 +658,7 @@ float SBF::GetFilterAPrioriFpp()
 
 // Returns the a-posteriori false positive probability over the entire filter
 // (i.e. not area-specific)
-float SBF::GetFilterFpp()
+float SBF::GetFilterFpp() const
 {
 	double p;
     int c = 0;
@@ -675,7 +675,7 @@ float SBF::GetFilterFpp()
 
 
 // Returns the expected emersion value for the input area
-float SBF::GetExpectedAreaEmersion(int area)
+float SBF::GetExpectedAreaEmersion(int area) const
 {
 	double p;
 	int nfill = 0;
@@ -692,7 +692,7 @@ float SBF::GetExpectedAreaEmersion(int area)
 
 
 // Returns the emersion value for the input area
-float SBF::GetAreaEmersion(int area)
+float SBF::GetAreaEmersion(int area) const
 {
     float ret, a, b;
     if((this->AREA_members[area]==0) || (this->HASH_number==0)) ret = -1;

--- a/sbf.h
+++ b/sbf.h
@@ -81,11 +81,11 @@ namespace sbf {
 
 		// Private methods (commented in the sbf.cpp)
 		void SetCell(unsigned int index, int area);
-		int GetCell(unsigned int index);
+		int GetCell(unsigned int index) const;
 		void CreateHashSalt(std::string path);
 		void LoadHashSalt(std::string path);
 		void SetHashDigestLength();
-		void Hash(char *d, size_t n, unsigned char *md);
+		void Hash(char *d, size_t n, unsigned char *md) const;
 
 
 	public:
@@ -226,21 +226,21 @@ namespace sbf {
 
 
 		// Public methods (commented in the sbf.cpp)
-		void PrintFilter(int mode);
+		void PrintFilter(int mode) const;
 		void SaveToDisk(std::string path, int mode);
 		void Insert(char *string, int size, int area);
-		int Check(char *string, int size);
-		int GetAreaMembers(int area);
-		float GetFilterSparsity();
-		float GetFilterFpp();
-		float GetFilterAPrioriFpp();
+		int Check(char *string, int size) const;
+		int GetAreaMembers(int area) const;
+		float GetFilterSparsity() const;
+		float GetFilterFpp() const;
+		float GetFilterAPrioriFpp() const;
 		void SetAreaFpp();
 		void SetAPrioriAreaFpp();
 		void SetAreaIsep();
 		void SetAPrioriAreaIsep();
 		void SetExpectedAreaCells();
-		float GetExpectedAreaEmersion(int area);
-		float GetAreaEmersion(int area);
+		float GetExpectedAreaEmersion(int area) const;
+		float GetAreaEmersion(int area) const;
 	};
 
 } //namespace sbf


### PR DESCRIPTION
- Move `base64.h` methods to the namespace `sbf` to inhibit collision with other libraries;
- Add `const` keyword on methods that don't have side-effects, to allow usage in other libraries.